### PR TITLE
Fix watch mode with multiple entry points, other refactoring

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,26 @@
 'use strict';
 
 var path = require('path');
-var rollup = require('rollup');
+var _rollup = require('rollup');
+
+// Rollup seems to have global state,
+// and so has strange behaviour when running multiple instances concurrently...
+var locked = false;
+var queue = [];
+
+function dequeue() {
+	if (queue.length) {
+		locked = true;
+		queue.shift()(_rollup).then(dequeue);
+	} else {
+		locked = false;
+	}
+}
+
+function withRollupInstance(callback) {
+	queue.push(callback);
+	if (!locked) dequeue();
+}
 
 function splitRequest(request) {
 	var split = request.split('!');
@@ -32,54 +51,56 @@ module.exports = function(source, sourceMap) {
 
 	var entryId = this.resourcePath;
 
-	rollup
-		.rollup({
-			entry: entryId,
-			external: external,
-			plugins: plugins.concat({
-				resolveId: function(id, importerId) {
-					if (id === entryId) {
-						return entryId;
-					} else {
-						return new Promise(function(resolve, reject) {
-							// split apart resource paths because Webpack's this.resolve() can't handle `loader!` prefixes
-							var parts = splitRequest(id);
-							var importerParts = splitRequest(importerId);
+	withRollupInstance(function(rollup) {
+		return rollup
+			.rollup({
+				entry: entryId,
+				external: external,
+				plugins: plugins.concat({
+					resolveId: function(id, importerId) {
+						if (id === entryId) {
+							return entryId;
+						} else {
+							return new Promise(function(resolve, reject) {
+								// split apart resource paths because Webpack's this.resolve() can't handle `loader!` prefixes
+								var parts = splitRequest(id);
+								var importerParts = splitRequest(importerId);
 
-							// resolve the full path of the imported file with Webpack's module loader
-							// this will figure out node_modules imports, Webpack aliases, etc.
-							this.resolve(path.dirname(importerParts.resource), parts.resource, function(err, fullPath) {
+								// resolve the full path of the imported file with Webpack's module loader
+								// this will figure out node_modules imports, Webpack aliases, etc.
+								this.resolve(path.dirname(importerParts.resource), parts.resource, function(err, fullPath) {
+									if (err) {
+										reject(err);
+									} else {
+										resolve(parts.loaders + fullPath);
+									}
+								});
+							}.bind(this));
+						}
+					}.bind(this),
+					load: function(id) {
+						if (id === entryId) {
+							return { code: source, map: sourceMap };
+						}
+						return new Promise(function(resolve, reject) {
+							// load the module with Webpack
+							// this will apply all relevant loaders, etc.
+							this.loadModule(id, function(err, source, map, module) {
 								if (err) {
 									reject(err);
-								} else {
-									resolve(parts.loaders + fullPath);
+									return;
 								}
+								resolve({ code: source, map: map });
 							});
 						}.bind(this));
-					}
-				}.bind(this),
-				load: function(id) {
-					if (id === entryId) {
-						return { code: source, map: sourceMap };
-					}
-					return new Promise(function(resolve, reject) {
-						// load the module with Webpack
-						// this will apply all relevant loaders, etc.
-						this.loadModule(id, function(err, source, map, module) {
-							if (err) {
-								reject(err);
-								return;
-							}
-							resolve({ code: source, map: map });
-						});
-					}.bind(this));
-				}.bind(this),
+					}.bind(this),
+				})
 			})
-		})
-		.then(function(bundle) {
-			var result = bundle.generate({ format: 'es', sourceMap: true });
-			callback(null, result.code, result.map);
-		}, function(err) {
-			callback(err);
-		});
+			.then(function(bundle) {
+				var result = bundle.generate({ format: 'es', sourceMap: true });
+				callback(null, result.code, result.map);
+			}, function(err) {
+				callback(err);
+			});
+	}.bind(this));
 };

--- a/index.js
+++ b/index.js
@@ -51,12 +51,10 @@ module.exports = function(source, sourceMap) {
 							this.resolve(path.dirname(importerParts.resource), parts.resource, function(err, fullPath) {
 								if (err) {
 									reject(err);
-									return;
+								} else {
+									resolve(parts.loaders + fullPath);
 								}
-								// add dependency for watch mode
-								this.addDependency(fullPath);
-								resolve(parts.loaders + fullPath);
-							}.bind(this));
+							});
 						}.bind(this));
 					}
 				}.bind(this),

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/erikdesjardins/webpack-rollup-loader#readme",
   "peerDependencies": {
-    "webpack": "^2.2.0"
+    "webpack": ">=2.2.0"
   },
   "dependencies": {
     "rollup": "^0.41.4"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "rollup": "^0.41.4"
   },
   "devDependencies": {
-    "ava": "^0.18.1",
-    "file-loader": "^0.10.0",
+    "ava": "^0.18.2",
+    "file-loader": "^0.10.1",
     "memory-fs": "^0.4.1",
     "rollup-plugin-commonjs": "^7.0.0",
     "webpack": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-rollup-loader",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Webpack loader that uses Rollup, which calls back into Webpack for module resolution.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Apparently Rollup has some global state...when there are multiple entry points, all of the rebuilds get dispatched to the same plugin's `resolveId` function (!), which cannot handle any entry point but its own.

Fix this by locking around Rollup compilation.